### PR TITLE
Removed [] & '' from language config (unsupported)

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -5,22 +5,17 @@
     },
     "brackets": [
       ["{", "}"],
-      ["[", "]"],
       ["(", ")"]
     ],
     "autoClosingPairs": [
       { "open": "{", "close": "}" },
-      { "open": "[", "close": "]" },
       { "open": "(", "close": ")" },
       { "open": "\"", "close": "\"" },
-      { "open": "'", "close": "'" }
     ],
     "surroundingPairs": [
       { "open": "{", "close": "}" },
-      { "open": "[", "close": "]" },
       { "open": "(", "close": ")" },
       { "open": "\"", "close": "\"" },
-      { "open": "'", "close": "'" }
     ]
 }
   


### PR DESCRIPTION
- Removed `[`, `]` and `'` from language config as they are not supported/used anywhere in CL