### PR TITLE
Added the undocumented parameter for Map.FindMapObjectsByComponent

### DIFF
--- a/src/classes/MapClass.ts
+++ b/src/classes/MapClass.ts
@@ -56,7 +56,9 @@ export class MapClass implements IClass {
             label: 'FindMapObjectsByComponent',
             returnType: 'List(MapObject)',
             description: 'Returns a list of map objects which have the corresponding CL component attached.',
-            parameters: []
+            parameters: [
+                { name: 'name', type: 'string', description: 'The name of the component on the map objects to find.' }
+            ]
         },
         {
             label: 'CreateMapObjectRaw',


### PR DESCRIPTION
It isn't in the official documentation yet, but `Map.FindMapObjectsByComponent` has a required `string` parameter which is the name of the component to search for. I call the parameter `name` based on the parameter name for the Component functions on `MapObject` which also accept a component name.