### PR TITLE
Improved hover markdown

### DIFF
--- a/src/completions/KeywordCompletionProvider.ts
+++ b/src/completions/KeywordCompletionProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as markdown from '../utils/MarkdownHelper';
 import { DocumentTreeProvider } from '../utils/DocumentTreeProvider';
 import { ClassKinds } from '../classes/IClass';
 
@@ -78,7 +79,7 @@ export class KeywordCompletionProvider implements vscode.CompletionItemProvider,
 
         const keyword = this.keywords.find(k => k.label === word);
         if (keyword) {
-            return new vscode.Hover(new vscode.MarkdownString(`**${keyword.label}**: ${keyword.description}`));
+            return new vscode.Hover(markdown.createKeywordMarkdown(keyword));
         }
 
         return undefined;

--- a/src/completions/VariableCompletionProvider.ts
+++ b/src/completions/VariableCompletionProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as markdown from '../utils/MarkdownHelper';
 import { CodeContextUtils } from '../utils/CodeContextUtils';
 import { ClassKinds, FindFieldInClassHierarchy, FindMethodInClassHierarchy, IClass, IConstructor, IField, IMethod, IParameter, IVariable, MethodKinds } from '../classes/IClass';
 import { VariableCollector } from '../utils/VariableCollector';
@@ -208,7 +209,7 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
                 let hoverContent: vscode.MarkdownString;
                 if ('kind' in resolvedType && 'name' in resolvedType) {
                     const classDef = resolvedType as IClass;
-                    hoverContent = this.buildClassMarkdown(classDef);
+                    hoverContent = markdown.createClassMarkdown(classDef);
                 } else if ('parameters' in resolvedType && 'returnType' in resolvedType) {
                     const methodDef = resolvedType as IMethod;
                     hoverContent = this.buildMethodMarkdown(methodDef);
@@ -243,7 +244,7 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
 
         const classDef = this.findClassByName(word);
         if (classDef) {
-            return new vscode.Hover(this.buildClassMarkdown(classDef), wordRange);
+            return new vscode.Hover(markdown.createClassMarkdown(classDef), wordRange);
         }
 
         const currentClass = this.documentTreeProvider.getCurrentClass(position);
@@ -555,10 +556,6 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
         });
         const paramsString = params.join(', ');
         return `(${paramsString})`;
-    }
-
-    private buildClassMarkdown(classDef: IClass): vscode.MarkdownString {
-        return new vscode.MarkdownString(`(${classDef.kind}) ${classDef.name}\n\n${classDef.description}`);
     }
 
     private buildFieldMarkdown(fieldDef: IField): vscode.MarkdownString {

--- a/src/completions/VariableCompletionProvider.ts
+++ b/src/completions/VariableCompletionProvider.ts
@@ -212,10 +212,10 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
                     hoverContent = markdown.createClassMarkdown(classDef);
                 } else if ('parameters' in resolvedType && 'returnType' in resolvedType) {
                     const methodDef = resolvedType as IMethod;
-                    hoverContent = this.buildMethodMarkdown(methodDef);
+                    hoverContent = markdown.createMethodMarkdown(methodDef, this.constructMethodSignature(methodDef));
                 } else if ('label' in resolvedType && 'type' in resolvedType) {
                     const fieldDef = resolvedType as IField;
-                    hoverContent = markdown.buildFieldMarkdown(fieldDef);
+                    hoverContent = markdown.createFieldMarkdown(fieldDef);
                 } else if ('name' in resolvedType && 'type' in resolvedType) {
                     const variableDef = resolvedType as IVariable;
                     hoverContent = this.buildVariableMarkdown(variableDef);
@@ -251,18 +251,18 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
         if (currentClass) {
             const fieldDef = FindFieldInClassHierarchy(currentClass, word, true, true, true, true);
             if (fieldDef) {
-                return new vscode.Hover(markdown.buildFieldMarkdown(fieldDef), wordRange);
+                return new vscode.Hover(markdown.createFieldMarkdown(fieldDef), wordRange);
             }
 
             const methodDef = FindMethodInClassHierarchy(currentClass, word, -1, true, true);
             if (methodDef) {
-                return new vscode.Hover(this.buildMethodMarkdown(methodDef), wordRange);
+                return new vscode.Hover(markdown.createMethodMarkdown(methodDef, this.constructMethodSignature(methodDef)), wordRange);
             }
         }
 
         const methodDef = this.findMethodByNameFromAllClasses(word);
         if (methodDef) {
-            return new vscode.Hover(this.buildMethodMarkdown(methodDef), wordRange);
+            return new vscode.Hover(markdown.createMethodMarkdown(methodDef, this.constructMethodSignature(methodDef)), wordRange);
         }
 
         return undefined;
@@ -556,10 +556,6 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
         });
         const paramsString = params.join(', ');
         return `(${paramsString})`;
-    }
-
-    private buildMethodMarkdown(methodDef: IMethod): vscode.MarkdownString {
-        return new vscode.MarkdownString(`${methodDef.kind ?? MethodKinds.FUNCTION} ${methodDef.label}${this.constructMethodSignature(methodDef)} ${methodDef.returnType}\n\n${methodDef.description}`);
     }
 
     private buildVariableMarkdown(variableDef: IVariable): vscode.MarkdownString {

--- a/src/completions/VariableCompletionProvider.ts
+++ b/src/completions/VariableCompletionProvider.ts
@@ -215,7 +215,7 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
                     hoverContent = this.buildMethodMarkdown(methodDef);
                 } else if ('label' in resolvedType && 'type' in resolvedType) {
                     const fieldDef = resolvedType as IField;
-                    hoverContent = this.buildFieldMarkdown(fieldDef);
+                    hoverContent = markdown.buildFieldMarkdown(fieldDef);
                 } else if ('name' in resolvedType && 'type' in resolvedType) {
                     const variableDef = resolvedType as IVariable;
                     hoverContent = this.buildVariableMarkdown(variableDef);
@@ -251,7 +251,7 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
         if (currentClass) {
             const fieldDef = FindFieldInClassHierarchy(currentClass, word, true, true, true, true);
             if (fieldDef) {
-                return new vscode.Hover(this.buildFieldMarkdown(fieldDef), wordRange);
+                return new vscode.Hover(markdown.buildFieldMarkdown(fieldDef), wordRange);
             }
 
             const methodDef = FindMethodInClassHierarchy(currentClass, word, -1, true, true);
@@ -556,10 +556,6 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
         });
         const paramsString = params.join(', ');
         return `(${paramsString})`;
-    }
-
-    private buildFieldMarkdown(fieldDef: IField): vscode.MarkdownString {
-        return new vscode.MarkdownString(`(${fieldDef.private ? 'private' : 'public'}${fieldDef.readonly ? ' readonly' : ''} field) ${fieldDef.label} ${fieldDef.type}\n\n${fieldDef.description}`);
     }
 
     private buildMethodMarkdown(methodDef: IMethod): vscode.MarkdownString {

--- a/src/completions/VariableCompletionProvider.ts
+++ b/src/completions/VariableCompletionProvider.ts
@@ -232,7 +232,7 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
             for (let i = 0; i < currentMethodDef.parameters.length; i++) {
                 const param = currentMethodDef.parameters[i];
                 if (param.name === word) {
-                    return new vscode.Hover(this.buildParameterMarkdown(param), wordRange);
+                    return new vscode.Hover(markdown.createParameterMarkdown(param), wordRange);
                 }
             }
         }
@@ -556,11 +556,5 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
         });
         const paramsString = params.join(', ');
         return `(${paramsString})`;
-    }
-
-    private buildParameterMarkdown(paramDef: IParameter): vscode.MarkdownString {
-        return new vscode.MarkdownString(
-            `(param) ${paramDef.name}: ${paramDef.type}`
-        );
     }
 }

--- a/src/completions/VariableCompletionProvider.ts
+++ b/src/completions/VariableCompletionProvider.ts
@@ -218,7 +218,7 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
                     hoverContent = markdown.createFieldMarkdown(fieldDef);
                 } else if ('name' in resolvedType && 'type' in resolvedType) {
                     const variableDef = resolvedType as IVariable;
-                    hoverContent = this.buildVariableMarkdown(variableDef);
+                    hoverContent = markdown.createVariableMarkdown(variableDef);
                 } else {
                     hoverContent = new vscode.MarkdownString(`Unknown type`);
                 }
@@ -239,7 +239,7 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
 
         if (this.declaredVariables.has(word)) {
             const variableInfo = this.declaredVariables.get(word);
-            return new vscode.Hover(this.buildVariableMarkdown(variableInfo!), wordRange);
+            return new vscode.Hover(markdown.createVariableMarkdown(variableInfo!), wordRange);
         }
 
         const classDef = this.findClassByName(word);
@@ -556,12 +556,6 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
         });
         const paramsString = params.join(', ');
         return `(${paramsString})`;
-    }
-
-    private buildVariableMarkdown(variableDef: IVariable): vscode.MarkdownString {
-        return new vscode.MarkdownString(
-            `(var) ${variableDef.name} ${variableDef.type} = ${variableDef.value}`
-        );
     }
 
     private buildParameterMarkdown(paramDef: IParameter): vscode.MarkdownString {

--- a/src/utils/MarkdownHelper.ts
+++ b/src/utils/MarkdownHelper.ts
@@ -1,0 +1,6 @@
+import { MarkdownString } from "vscode";
+
+export function createKeywordMarkdown(keyword: { label: string; description: string }): MarkdownString {
+    const md = `\`\`\`acl\n${keyword.label}\n\`\`\` \n\n---\n\n ${keyword.description}`;
+    return new MarkdownString(md);
+}

--- a/src/utils/MarkdownHelper.ts
+++ b/src/utils/MarkdownHelper.ts
@@ -1,5 +1,5 @@
 import { MarkdownString } from "vscode";
-import { IClass, IField } from "../classes/IClass";
+import { IClass, IField, IMethod, MethodKinds } from "../classes/IClass";
 
 const horizontalLine: string = "\n\n---\n\n";
 
@@ -16,7 +16,7 @@ export function createClassMarkdown(classDef: IClass): MarkdownString {
     return new MarkdownString(md);
 }
 
-export function buildFieldMarkdown(fieldDef: IField): MarkdownString {
+export function createFieldMarkdown(fieldDef: IField): MarkdownString {
     const m1 = fieldDef.private ? 'private' : 'public';
     const m2 = fieldDef.readonly ? ' readonly' : '';
     
@@ -26,6 +26,15 @@ export function buildFieldMarkdown(fieldDef: IField): MarkdownString {
         m4 += `${horizontalLine} ${fieldDef.description}`;
     }
     return new MarkdownString(m4);
+}
+
+export function createMethodMarkdown(methodDef: IMethod, methodSignature: string): MarkdownString {
+    const kind = methodDef.kind ?? MethodKinds.FUNCTION;
+    var md = wrapLang(`${kind} ${methodDef.label}${methodSignature} ${methodDef.returnType}`);
+    if (methodDef.description !== "") {
+        md += `${horizontalLine} ${methodDef.description}`;
+    }
+    return new MarkdownString(md);
 }
 
 function wrapLang(code: string, language: string = "acl"): string {

--- a/src/utils/MarkdownHelper.ts
+++ b/src/utils/MarkdownHelper.ts
@@ -1,5 +1,5 @@
 import { MarkdownString } from "vscode";
-import { IClass, IField, IMethod, IVariable, MethodKinds } from "../classes/IClass";
+import { IClass, IField, IMethod, IParameter, IVariable, MethodKinds } from "../classes/IClass";
 
 const horizontalLine: string = "\n\n---\n\n";
 
@@ -39,6 +39,11 @@ export function createMethodMarkdown(methodDef: IMethod, methodSignature: string
 
 export function createVariableMarkdown(variableDef: IVariable): MarkdownString {
     const md = wrapLang(`(local variable) ${variableDef.name} ${variableDef.type} = ${variableDef.value}`);
+    return new MarkdownString(md);
+}
+
+export function createParameterMarkdown(paramDef: IParameter): MarkdownString {
+    const md = wrapLang(`(parameter) ${paramDef.name} ${paramDef.type}`);
     return new MarkdownString(md);
 }
 

--- a/src/utils/MarkdownHelper.ts
+++ b/src/utils/MarkdownHelper.ts
@@ -1,5 +1,5 @@
 import { MarkdownString } from "vscode";
-import { IClass, IField, IMethod, MethodKinds } from "../classes/IClass";
+import { IClass, IField, IMethod, IVariable, MethodKinds } from "../classes/IClass";
 
 const horizontalLine: string = "\n\n---\n\n";
 
@@ -34,6 +34,11 @@ export function createMethodMarkdown(methodDef: IMethod, methodSignature: string
     if (methodDef.description !== "") {
         md += `${horizontalLine} ${methodDef.description}`;
     }
+    return new MarkdownString(md);
+}
+
+export function createVariableMarkdown(variableDef: IVariable): MarkdownString {
+    const md = wrapLang(`(local variable) ${variableDef.name} ${variableDef.type} = ${variableDef.value}`);
     return new MarkdownString(md);
 }
 

--- a/src/utils/MarkdownHelper.ts
+++ b/src/utils/MarkdownHelper.ts
@@ -1,6 +1,21 @@
 import { MarkdownString } from "vscode";
+import { IClass } from "../classes/IClass";
+
+const horizontalLine: string = "\n\n---\n\n";
 
 export function createKeywordMarkdown(keyword: { label: string; description: string }): MarkdownString {
-    const md = `\`\`\`acl\n${keyword.label}\n\`\`\` \n\n---\n\n ${keyword.description}`;
+    const md = `${wrapLang(keyword.label)} ${horizontalLine} ${keyword.description}`;
     return new MarkdownString(md);
+}
+
+export function createClassMarkdown(classDef: IClass): MarkdownString {
+    var md = wrapLang(`${classDef.kind} ${classDef.name}`);
+    if (classDef.description !== "") {
+        md += `${horizontalLine} ${classDef.description}`;
+    }
+    return new MarkdownString(md);
+}
+
+function wrapLang(code: string, language: string = "acl"): string {
+    return `\`\`\`${language}\n${code}\n\`\`\``;
 }

--- a/src/utils/MarkdownHelper.ts
+++ b/src/utils/MarkdownHelper.ts
@@ -1,5 +1,5 @@
 import { MarkdownString } from "vscode";
-import { IClass } from "../classes/IClass";
+import { IClass, IField } from "../classes/IClass";
 
 const horizontalLine: string = "\n\n---\n\n";
 
@@ -16,6 +16,34 @@ export function createClassMarkdown(classDef: IClass): MarkdownString {
     return new MarkdownString(md);
 }
 
+export function buildFieldMarkdown(fieldDef: IField): MarkdownString {
+    const m1 = fieldDef.private ? 'private' : 'public';
+    const m2 = fieldDef.readonly ? ' readonly' : '';
+    
+    const m3 = `(${m1}${m2} field) ${fieldDef.label} ${fieldDef.type}`;
+    var m4 = wrapLang(m3, "csharp");
+    if (fieldDef.description !== "") {
+        m4 += `${horizontalLine} ${fieldDef.description}`;
+    }
+    return new MarkdownString(m4);
+}
+
 function wrapLang(code: string, language: string = "acl"): string {
-    return `\`\`\`${language}\n${code}\n\`\`\``;
+    return '\n' + appendEscapedMarkdownCodeBlockFence(code, language) + '\n';
+}
+
+// https://github.com/microsoft/vscode/blob/main/src/vs/base/common/htmlContent.ts#L145
+export function appendEscapedMarkdownCodeBlockFence(code: string, langId: string) {
+	const longestFenceLength =
+		code.match(/^`+/gm)?.reduce((a, b) => (a.length > b.length ? a : b)).length ??
+		0;
+	const desiredFenceLength =
+		longestFenceLength >= 3 ? longestFenceLength + 1 : 3;
+
+	// the markdown result
+	return [
+		`${'`'.repeat(desiredFenceLength)}${langId}`,
+		code,
+		`${'`'.repeat(desiredFenceLength)}`,
+	].join('\n');
 }


### PR DESCRIPTION
### keywords
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/a6e342f9-797c-42db-b329-e8e959aa0caa" alt="Before"></td>
    <td><img src="https://github.com/user-attachments/assets/3e8c94e2-4b5e-4335-9409-5b4e477fa42b" alt="After"></td>
  </tr>
</table>

### classes
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/0805904a-4f3b-4ee6-8020-0235453c39bf" alt="Before"></td>
    <td><img src="https://github.com/user-attachments/assets/a1009d44-d51b-4f3c-bcc7-0308c046bf89" alt="After"></td>
  </tr>
</table>

### fields
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/324fb3ca-e362-43e9-8a0e-9aa60c27ef6a" alt="Before"></td>
    <td><img src="https://github.com/user-attachments/assets/5095bdb8-f074-412e-b211-909f924ca6fb" alt="After"></td>
  </tr>
</table>

### methods
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/67fa7a9f-e180-46af-aa9c-df5bf31a5846" alt="Before"></td>
    <td><img src="https://github.com/user-attachments/assets/7e9955d9-e499-4009-9fe1-2326cd1ecd71" alt="After"></td>
  </tr>
</table>

variables and parameters are mostly the same as before except I changed "var" to "local variable" and "param" to "parameter"