### PR TITLE
Release/0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the "aottg2cl" extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2025-07-18
+
+### Added
+
+- New build command: "Build Custom Logic Into Custom Map"
+  - Inserts logic into existing Custom Map file between `/// Logic` and `/// Weather` boundaries
+  - Available via Ctrl + Shift + P and Ctrl + Shift + B
+- Completion settings:
+  - New setting to disable automatic parameter completion in method calls and constructors
+- README.md documentation update
+  - Enhanced annotation examples with generic types (List<T>, Dict<K,V>)
+  - Added modular imports documentation with complete examples
+  - Added commands documentation
+
 ## [0.1.3] - 2025-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,8 +46,114 @@ class AnnotationsDemo
     {
         return 83;
     }
+    
+    function GenericsExample()
+    {
+        # @type List<Vector3>
+        positions = List();
+        
+        # @type Dict<string, Timer>
+        timers = Dict();
+        
+        # @type Dict<int, List<Human>>
+        teamPlayers = Dict();
+        
+        # @type List<Dict<string, float>>
+        playerStats = List();
+    }
 }
 ```
+
+### Modular imports support
+
+Use `# @import fileName1 fileName2` annotations in the beginning of your files to import other script files.
+
+#### Example file structure
+```
+|---yourFolder/
+|     portal2.cl
+|     router.cl
+|     enums.cl
+|     ui_enums.cl
+```
+
+#### Import syntax
+
+You can import multiple files in one line:
+```csharp
+# @import fileName1 fileName2
+```
+
+Or use separate import lines:
+```csharp
+# @import fileName1
+# @import fileName2
+```
+
+#### Complete example
+
+**portal2.cl**
+```csharp
+# @import router enums
+
+class Main
+{
+    /*_*/
+}
+```
+
+**enums.cl**
+```csharp
+# @import ui_enums
+
+extension KeyBindsEnum
+{
+    GENERAL_FORWARD = "General/Forward";
+    GENERAL_BACK = "General/Back";
+    GENERAL_LEFT = "General/Left";
+    GENERAL_RIGHT = "General/Right";
+    GENERAL_UP = "General/Up";
+    /*_*/
+}
+```
+
+**ui_enums.cl**
+```csharp
+extension UIPosEnum
+{
+    TOPCENTER = "TopCenter";
+    TOPLEFT = "TopLeft";
+    TOPRIGHT = "TopRight";
+    /*_*/
+}
+```
+
+**router.cl**
+```csharp
+class Router
+{
+    /*_*/
+}
+```
+
+### Build commands
+
+The extension provides two build commands accessible via `Ctrl + Shift + P`:
+
+#### Build Custom Logic
+Builds all imported files into a single final script file. Choose name and destination for the output file.
+
+Available via:
+- `Ctrl + Shift + P` > "Build Custom Logic"
+- `Ctrl + Shift + B` > "Build Custom Logic"
+
+#### Build Custom Logic Into Custom Map
+
+Available via:
+- `Ctrl + Shift + P` > "Build Custom Logic Into Custom Map"
+- `Ctrl + Shift + B` > "Build Custom Logic Into Custom Map"
+
+Builds all imported files and injects the result into an existing Custom Map file between `/// Logic` and `/// Weather` boundaries.
 
 ### VSCode Extensions Hub
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aottg2cl",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aottg2cl",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
       },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,11 @@
     "commands": [
       {
         "command": "extension.buildScript",
-        "title": "Build Final ACL Script"
+        "title": "Build Custom Logic"
+      },
+      {
+        "command": "extension.buildScriptIntoMap",
+        "title": "Build Custom Logic Into Custom Map"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aottg2cl",
   "displayName": "AoTTG 2 Custom Logic Language Support",
   "description": "Syntax highlighting and autocomplete for AoTTG 2 Custom Logic",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "Jagerente",
   "repository": {
     "type": "git",
@@ -94,6 +94,11 @@
           "type": "boolean",
           "default": true,
           "description": "Remember the last filename used when saving the final file."
+        },
+        "aottg2cl.completion.disableAutoParameters": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable automatic parameter completion in function calls. When enabled, only empty parentheses will be inserted."
         }
       }
     }

--- a/src/commands/BuildFinalFileIntoMap.ts
+++ b/src/commands/BuildFinalFileIntoMap.ts
@@ -1,0 +1,115 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import {buildImportChain} from '../utils/DependencyChain';
+import {extensionContext} from '../extension';
+import {Settings} from '../config/settings';
+
+export async function buildFinalFileIntoMap() {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        vscode.window.showErrorMessage('No active file.');
+        return;
+    }
+    const mainUri = editor.document.uri;
+
+    const rememberPath = Settings.rememberLastPath;
+    const rememberName = Settings.rememberLastName;
+    const lastMapPath: string | undefined = extensionContext.globalState.get('lastMapPath');
+    const lastMapName: string | undefined = extensionContext.globalState.get('lastMapName');
+
+    const defaultDir = (rememberPath && lastMapPath)
+        ? lastMapPath
+        : path.dirname(mainUri.fsPath);
+
+    const defaultFileName = (rememberName && lastMapName) ? lastMapName : '';
+    const defaultUri = defaultFileName 
+        ? vscode.Uri.file(path.join(defaultDir, defaultFileName))
+        : vscode.Uri.file(defaultDir);
+
+    const mapFileUri = await vscode.window.showOpenDialog({
+        canSelectFiles: true,
+        canSelectFolders: false,
+        canSelectMany: false,
+        filters: {'Custom Map Files': ['txt', 'cl'], 'All Files': ['*']},
+        openLabel: 'Select Custom Map File',
+        defaultUri: defaultUri
+    });
+
+    if (!mapFileUri || mapFileUri.length === 0) {
+        return;
+    }
+
+    const targetMapFile = mapFileUri[0];
+
+    try {
+        const importChain = await buildImportChain(mainUri);
+        let finalContent = '';
+        const definedClasses = new Map<string, string>();
+        
+        const mainContentRaw = await fs.readFile(mainUri.fsPath, 'utf-8');
+        const mainContent = mainContentRaw.replace(/^#\s*@import.*$/gm, '').trim();
+        const classRegex = /class\s+(\w+)\s*{/g;
+        let match;
+        
+        while ((match = classRegex.exec(mainContent)) !== null) {
+            definedClasses.set(match[1], mainUri.fsPath);
+        }
+        finalContent += mainContent + '\n\n';
+        
+        for (const file of importChain) {
+            const contentRaw = await fs.readFile(file, 'utf-8');
+            const content = contentRaw.replace(/^#\s*@import.*$/gm, '').trim();
+            classRegex.lastIndex = 0;
+            while ((match = classRegex.exec(content)) !== null) {
+                const className = match[1];
+                if (definedClasses.has(className)) {
+                    throw new Error(`Duplicate class definition detected: ${className} found in ${definedClasses.get(className)} and ${file}`);
+                }
+                definedClasses.set(className, file);
+            }
+            finalContent += content + '\n\n';
+        }
+
+        const mapContent = await fs.readFile(targetMapFile.fsPath, 'utf-8');
+        
+        const logicStartMatch = mapContent.match(/^[ \t]*\/\/\/\s*Logic\s*$/im);
+        const weatherStartMatch = mapContent.match(/^[ \t]*\/\/\/\s*Weather\s*$/im);
+        
+        if (!logicStartMatch || !weatherStartMatch) {
+            throw new Error('Invalid Custom Map file selected. The file must contain both "/// Logic" and "/// Weather" boundaries to insert Custom Logic content.');
+        }
+
+        const logicStartIndex = logicStartMatch.index! + logicStartMatch[0].length;
+        const weatherStartIndex = weatherStartMatch.index!;
+
+        if (logicStartIndex >= weatherStartIndex) {
+            throw new Error('Invalid Custom Map file structure. "/// Logic" boundary must appear before "/// Weather" boundary.');
+        }
+
+        const beforeLogic = mapContent.substring(0, logicStartIndex);
+        const afterWeather = mapContent.substring(weatherStartIndex);
+        
+        const newMapContent = beforeLogic + '\n' + finalContent.trim() + '\n' + afterWeather;
+
+        await fs.writeFile(targetMapFile.fsPath, newMapContent, 'utf-8');
+
+        if (rememberPath) {
+            extensionContext.globalState.update('lastMapPath', path.dirname(targetMapFile.fsPath));
+        }
+        if (rememberName) {
+            extensionContext.globalState.update('lastMapName', path.basename(targetMapFile.fsPath));
+        }
+
+        vscode.window.showInformationMessage(
+            `Custom Logic successfully injected into ${path.basename(targetMapFile.fsPath)}.`,
+            'Open File Location'
+        ).then(selection => {
+            if (selection === 'Open File Location') {
+                vscode.commands.executeCommand('revealFileInOS', targetMapFile);
+            }
+        });
+    } catch (error: any) {
+        vscode.window.showErrorMessage(error.message);
+    }
+} 

--- a/src/completions/VariableCompletionProvider.ts
+++ b/src/completions/VariableCompletionProvider.ts
@@ -15,6 +15,10 @@ import {
 
 import { DocumentTreeProvider } from '../utils/DocumentTreeProvider';
 
+const PRIORITY_STATIC = '0';
+const PRIORITY_CONSTRUCTOR = '1';
+const PRIORITY_VARIABLE = '2';
+
 export class VariableCompletionProvider implements vscode.CompletionItemProvider, vscode.HoverProvider, vscode.SignatureHelpProvider {
     private documentTreeProvider: DocumentTreeProvider;
 
@@ -191,9 +195,31 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
             if (classDef.hidden) {
                 return;
             }
+            const hasStatics = (classDef.staticFields?.length ?? 0) > 0 || (classDef.staticMethods?.length ?? 0) > 0;
+            const hasParentStatics = (classDef.extends ?? []).some(parent =>
+                (parent.staticFields?.length ?? 0) > 0 || (parent.staticMethods?.length ?? 0) > 0
+            );
+            if (!hasStatics && !hasParentStatics) {
+                return;
+            }
+
+            const classItem = new vscode.CompletionItem(classDef.name, vscode.CompletionItemKind.Class);
+            classItem.detail = `${classDef.kind} ${classDef.name}`;
+            classItem.documentation = new vscode.MarkdownString(classDef.description);
+            if (wordRange) {
+                classItem.range = wordRange;
+            }
+            classItem.sortText = `${PRIORITY_STATIC}_${classDef.name}`;
+            items.push(classItem);
+        });
+
+        this.documentTreeProvider.getAllAvailableClasses(document).forEach(classDef => {
+            if (classDef.hidden) {
+                return;
+            }
 
             if (classDef.constructors && classDef.constructors.length > 0) {
-                classDef.constructors.forEach(constructor => {
+                classDef.constructors.forEach((constructor, index) => {
                     const item = new vscode.CompletionItem(classDef.name, vscode.CompletionItemKind.Constructor);
                     item.detail = `constructor ${this.constructMethodSignature(constructor)}: ${classDef.name}`;
                     if (classDef.constructors!.length > 1) {
@@ -210,6 +236,7 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
                     }).join(', ');
 
                     item.insertText = new vscode.SnippetString(`${classDef.name}(${snippetParams})`);
+                    item.sortText = `${PRIORITY_CONSTRUCTOR}_${classDef.name}_${index}`;
                     items.push(item);
                 });
             } else if (classDef.kind === ClassKinds.CLASS) {
@@ -220,7 +247,7 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
                 if (wordRange) {
                     defaultConstructor.range = wordRange;
                 }
-
+                defaultConstructor.sortText = `${PRIORITY_CONSTRUCTOR}_${classDef.name}`;
                 items.push(defaultConstructor);
             }
         });
@@ -243,6 +270,7 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
                 if (wordRange) {
                     item.range = wordRange;
                 }
+                item.sortText = `${PRIORITY_VARIABLE}_${details.name}`;
                 items.push(item);
             }
 
@@ -258,22 +286,10 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
                 if (wordRange) {
                     item.range = wordRange;
                 }
+                item.sortText = `${PRIORITY_VARIABLE}_${param.name}`;
                 items.push(item);
             }
         }
-
-        this.documentTreeProvider.getAllAvailableClasses(document).forEach(classDef => {
-            if (classDef.kind !== ClassKinds.EXTENSION) {
-                return;
-            }
-            const classItem = new vscode.CompletionItem(classDef.name, vscode.CompletionItemKind.Class);
-            classItem.detail = `${classDef.kind} ${classDef.name}`;
-            classItem.documentation = new vscode.MarkdownString(classDef.description);
-            if (wordRange) {
-                classItem.range = wordRange;
-            }
-            items.push(classItem);
-        });
 
         return items;
     }

--- a/src/completions/VariableCompletionProvider.ts
+++ b/src/completions/VariableCompletionProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as markdown from '../utils/MarkdownHelper';
 import { CodeContextUtils } from '../utils/CodeContextUtils';
+import { Settings } from '../config/settings';
 import {
     ClassKinds,
     FindFieldInClassHierarchy,
@@ -128,14 +129,15 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
                     item.range = wordRange;
                 }
 
-                const snippetParams = method.parameters.map((param, index) => {
-                    const placeholder = `\${${index + 1}:${param.name}}`;
-                    return param.isVariadic ? `...${placeholder}` : placeholder;
-                }).join(', ');
-
                 if (nextIsParen) {
                     item.insertText = new vscode.SnippetString(method.label);
+                } else if (Settings.disableAutoParameters) {
+                    item.insertText = new vscode.SnippetString(`${method.label}($1)`);
                 } else {
+                    const snippetParams = method.parameters.map((param, index) => {
+                        const placeholder = `\${${index + 1}:${param.name}}`;
+                        return param.isVariadic ? `...${placeholder}` : placeholder;
+                    }).join(', ');
                     item.insertText = new vscode.SnippetString(`${method.label}(${snippetParams})`);
                 }
                 items.push(item);
@@ -165,14 +167,15 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
                     item.range = wordRange;
                 }
 
-                const snippetParams = method.parameters.map((param, index) => {
-                    const placeholder = `\${${index + 1}:${param.name}}`;
-                    return param.isVariadic ? `...${placeholder}` : placeholder;
-                }).join(', ');
-
                 if (nextIsParen) {
                     item.insertText = new vscode.SnippetString(method.label);
+                } else if (Settings.disableAutoParameters) {
+                    item.insertText = new vscode.SnippetString(`${method.label}($1)`);
                 } else {
+                    const snippetParams = method.parameters.map((param, index) => {
+                        const placeholder = `\${${index + 1}:${param.name}}`;
+                        return param.isVariadic ? `...${placeholder}` : placeholder;
+                    }).join(', ');
                     item.insertText = new vscode.SnippetString(`${method.label}(${snippetParams})`);
                 }
                 items.push(item);
@@ -230,12 +233,15 @@ export class VariableCompletionProvider implements vscode.CompletionItemProvider
                         item.range = wordRange;
                     }
 
-                    const snippetParams = constructor.parameters.map((param, index) => {
-                        const placeholder = `\${${index + 1}:${param.name}}`;
-                        return param.isVariadic ? `...${placeholder}` : placeholder;
-                    }).join(', ');
-
-                    item.insertText = new vscode.SnippetString(`${classDef.name}(${snippetParams})`);
+                    if (Settings.disableAutoParameters) {
+                        item.insertText = new vscode.SnippetString(`${classDef.name}($1)`);
+                    } else {
+                        const snippetParams = constructor.parameters.map((param, index) => {
+                            const placeholder = `\${${index + 1}:${param.name}}`;
+                            return param.isVariadic ? `...${placeholder}` : placeholder;
+                        }).join(', ');
+                        item.insertText = new vscode.SnippetString(`${classDef.name}(${snippetParams})`);
+                    }
                     item.sortText = `${PRIORITY_CONSTRUCTOR}_${classDef.name}_${index}`;
                     items.push(item);
                 });

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -34,4 +34,8 @@ export class Settings {
     public static get rememberLastName(): boolean {
         return Settings.config.get<boolean>('build.rememberLastName', false);
     }
+
+    public static get disableAutoParameters(): boolean {
+        return Settings.config.get<boolean>('completion.disableAutoParameters', false);
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,9 @@ import {ACLManager} from './antlr4ts/ACLManager';
 import {DiagnosticManager} from './diagnostic/DiagnosticManager';
 import {DocumentTreeProvider} from './utils/DocumentTreeProvider';
 import {buildFinalFile} from './commands/BuildFinalFile';
+import {buildFinalFileIntoMap} from './commands/BuildFinalFileIntoMap';
 import {BuildFinalFileTaskProvider} from './tasks/BuildFinalFileTaskProvider';
+import {BuildFinalFileIntoMapTaskProvider} from './tasks/BuildFinalFileIntoMapTaskProvider';
 import {ACLFormatter} from './formatting/ACLFormatter';
 
 export let extensionContext: vscode.ExtensionContext;
@@ -39,8 +41,10 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.languages.registerDocumentFormattingEditProvider({language: 'acl'}, formatter),
         diagnosticCollection,
         vscode.commands.registerCommand('extension.buildScript', buildFinalFile),
+        vscode.commands.registerCommand('extension.buildScriptIntoMap', buildFinalFileIntoMap),
         vscode.languages.registerDocumentSymbolProvider({language: 'acl', scheme: 'file'}, symbolProvider),
-        vscode.tasks.registerTaskProvider(BuildFinalFileTaskProvider.type, new BuildFinalFileTaskProvider())
+        vscode.tasks.registerTaskProvider(BuildFinalFileTaskProvider.type, new BuildFinalFileTaskProvider()),
+        vscode.tasks.registerTaskProvider(BuildFinalFileIntoMapTaskProvider.type, new BuildFinalFileIntoMapTaskProvider())
     );
 
     const refetchDocumentData = async (document: vscode.TextDocument) => {

--- a/src/tasks/BuildFinalFileIntoMapTaskProvider.ts
+++ b/src/tasks/BuildFinalFileIntoMapTaskProvider.ts
@@ -1,19 +1,19 @@
 import * as vscode from 'vscode';
 
-export class BuildFinalFileTaskProvider implements vscode.TaskProvider {
+export class BuildFinalFileIntoMapTaskProvider implements vscode.TaskProvider {
     static type = 'acl';
 
     provideTasks(): vscode.Task[] {
-        const def: vscode.TaskDefinition = {type: BuildFinalFileTaskProvider.type, task: 'build'};
+        const def: vscode.TaskDefinition = {type: BuildFinalFileIntoMapTaskProvider.type, task: 'build-into-map'};
         const execution = new vscode.CustomExecution(async (): Promise<vscode.Pseudoterminal> => {
-            return new BuildPseudoterminal();
+            return new BuildIntoMapPseudoterminal();
         });
 
         const task = new vscode.Task(
             def,
             vscode.TaskScope.Workspace,
-            'Build Custom Logic',
-            BuildFinalFileTaskProvider.type,
+            'Build Custom Logic Into Custom Map',
+            BuildFinalFileIntoMapTaskProvider.type,
             execution
         );
         task.group = vscode.TaskGroup.Build;
@@ -24,7 +24,8 @@ export class BuildFinalFileTaskProvider implements vscode.TaskProvider {
         return task;
     }
 }
-class BuildPseudoterminal implements vscode.Pseudoterminal {
+
+class BuildIntoMapPseudoterminal implements vscode.Pseudoterminal {
     private writeEmitter = new vscode.EventEmitter<string>();
     onDidWrite = this.writeEmitter.event;
     
@@ -32,14 +33,14 @@ class BuildPseudoterminal implements vscode.Pseudoterminal {
     onDidClose = this.closeEmitter.event;
 
     open(_initialDimensions: vscode.TerminalDimensions | undefined): void {
-        vscode.commands.executeCommand('extension.buildScript')
+        vscode.commands.executeCommand('extension.buildScriptIntoMap')
             .then(
                 () => {
-                    this.writeEmitter.fire('Build command executed.\r\n');
+                    this.writeEmitter.fire('Build into map command executed.\r\n');
                     this.close();
                 },
                 err => {
-                    this.writeEmitter.fire(`Build command failed: ${err?.message || err}\r\n`);
+                    this.writeEmitter.fire(`Build into map command failed: ${err?.message || err}\r\n`);
                     this.close();
                 }
             );
@@ -48,5 +49,4 @@ class BuildPseudoterminal implements vscode.Pseudoterminal {
     close(): void {
         this.closeEmitter.fire();
     }
-}
-
+} 


### PR DESCRIPTION
### Added

- New build command: "Build Custom Logic Into Custom Map"
  - Inserts logic into existing Custom Map file between `/// Logic` and `/// Weather` boundaries
  - Available via Ctrl + Shift + P and Ctrl + Shift + B
- Completion settings:
  - New setting to disable automatic parameter completion in method calls and constructors
- README.md documentation update
  - Enhanced annotation examples with generic types (List<T>, Dict<K,V>)
  - Added modular imports documentation with complete examples
  - Added commands documentation